### PR TITLE
Updated supported OS's.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out git repository.
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: 'glillico.configure_sshd'
 
       - name: Setup python 3.
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
@@ -35,6 +35,39 @@ jobs:
         run: |
           yamllint .
 
+  molecule-legacy:
+    needs: lint
+    name: Molecule (Ansible 2.16.x)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - rockylinux8
+        tag:
+          - latest
+    steps:
+      - name: Check out git repository.
+        uses: actions/checkout@v4
+        with:
+          path: 'glillico.configure_sshd'
+
+      - name: Setup python 3.
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install package dependencies.
+        run: pip3 install "ansible-core<2.17" docker molecule "molecule-plugins[docker]"
+
+      - name: Perform molecule tests.
+        run: molecule test
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_DISTRO: ${{ matrix.distro }}
+          MOLECULE_TAG: ${{ matrix.tag }}
+
   molecule:
     needs: lint
     name: Molecule
@@ -43,23 +76,21 @@ jobs:
       fail-fast: false
       matrix:
         distro:
-          - centos7
-          - debian10
           - debian11
-          - rockylinux8
+          - debian12
           - rockylinux9
-          - ubuntu2004
           - ubuntu2204
+          - ubuntu2404
         tag:
           - latest
     steps:
       - name: Check out git repository.
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: 'glillico.configure_sshd'
 
       - name: Setup python 3.
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 


### PR DESCRIPTION
also added separate test section for Rocky Linux 8 that uses ansible 2.16.x due to https://github.com/ansible/ansible/issues/83357 and updated the version of actions/checkout and actions/setup-python.
